### PR TITLE
expose default health check port 8081

### DIFF
--- a/node-agent-example-docker/Dockerfile
+++ b/node-agent-example-docker/Dockerfile
@@ -21,4 +21,5 @@ COPY --from=build /etc/ssl/certs /etc/ssl/certs
 
 # start the server by default, this can be overwritten at runtime
 EXPOSE 8081
+
 CMD [ "node", "./dist/agent.js", "start" ]

--- a/python-agent-example-app/Dockerfile
+++ b/python-agent-example-app/Dockerfile
@@ -44,5 +44,8 @@ COPY . .
 # ensure that any dependent models are downloaded at build-time
 RUN python main.py download-files
 
+# expose healthcheck port
+EXPOSE 8081
+
 # Run the application.
 CMD ["python", "main.py", "start"]


### PR DESCRIPTION
Google Cloud Run (and probably others) use docker exposed ports. health checks tends to fail when not exposing them