### PR TITLE
allow python to write bytecode

### DIFF
--- a/python-agent-example-app/Dockerfile
+++ b/python-agent-example-app/Dockerfile
@@ -6,10 +6,6 @@ FROM python:${PYTHON_VERSION}-slim
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
 
-# Keeps Python from buffering stdout and stderr to avoid situations where
-# the application crashes without emitting any logs due to buffering.
-ENV PYTHONUNBUFFERED=1
-
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 ARG UID=10001


### PR DESCRIPTION
this is only applicable in read-only file systems and allowing bytecode will speed up starts