### PR TITLE
renaming render.com to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following examples include a template configuration or manifest file for eac
 | [Cerebrium](/cerebrium) | `cerebrium.toml` example for [Cerebrium](https://cerebrium.ai) |
 | [Fly.io](/fly.io) | `fly.toml` example for [Fly.io](https://fly.io) |
 | [Kubernetes](/kubernetes) | Example manifest file for any Kubernetes environment |
-| [Render.com](/render.com) | `render.yaml` example for [Render](https://render.com) |
+| [Render](/render.com) | `render.yaml` example for [Render](https://render.com) |
 
 ## Missing a provider?
 

--- a/render/README.md
+++ b/render/README.md
@@ -1,6 +1,6 @@
-# Render.com LiveKit Agents Deployment Example
+# Render LiveKit Agents Deployment Example
 
-This directory demonstrates how to deploy LiveKit Agents to [Render.com](https://render.com).
+This directory demonstrates how to deploy LiveKit Agents to [Render](https://render.com).
 
 You also need a working agents app and Dockerfile. See the examples for [Python](/python-agent-example-app) or [Node.js](/node-agent-example-docker) if necessary.
 
@@ -12,7 +12,7 @@ Copy the `render.yaml` file to the root of your project (wherever your `Dockerfi
 
 ### Create environment group
 
-In your [Render.com dashboard](https://dashboard.render.com) you'll need to create an environment group to store LiveKit secrets.
+In your [Render dashboard](https://dashboard.render.com) you'll need to create an environment group to store LiveKit secrets.
 Create an environment group with the name `agent-example-env-group` with the variables:
 ```bash
 LIVEKIT_URL=wss://your-livekit-url.livekit.cloud
@@ -22,7 +22,7 @@ LIVEKIT_API_SECRET=your-livekit-api-secret
 
 ### Launch your service
 
-To launch your service, create a blueprint in your Render.com dashboard
+To launch your service, create a blueprint in your Render dashboard
 pointing to your repo.
 
 This will find the `render.yaml` file and apply it's changes. You can use

--- a/render/render.yaml
+++ b/render/render.yaml
@@ -17,7 +17,7 @@ services:
   - fromGroup: agent-example-env 
   region: virginia
 
-  # 300s is the standard allowed maximum. Talk to render.com support if you need this increased.
+  # 300s is the standard allowed maximum. Talk to Render support if you need this increased.
   maxShutdownDelaySeconds: 300
 
   # Sane defaults


### PR DESCRIPTION
renames instances of render.com to render. will update docs ref to this as well. 

do we know of any other instances that point to this example that will need to be renamed? i can set up a redirect or just manually search. seems like docs would be the main one. just lmk standard expected process. 