### PR TITLE
Update deployment documentation and add LiveKit Cloud section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains a collection of examples to deploy [LiveKit Agents](htt
 
 For more information about deployment, see the [documentation](https://docs.livekit.io/deploy/agents/).
 
-## LiveKit Cloud
+## Agents on LiveKit Cloud
 
-The easiest way to deploy an agent is to [deploy it to LiveKit Cloud](https://docs.livekit.io/deploy/agents/). LiveKit Cloud runs your agent on LiveKit's global network and infrastructure, with automatic scaling and load balancing, secrets management, and built-in metrics and log forwarding. Deployments are driven by a single LiveKit CLI command and use your existing Dockerfile.
+The easiest way to ship an agent is [agent deployment on LiveKit Cloud](https://docs.livekit.io/deploy/agents/). Your agent runs on LiveKit's global network and infrastructure, with automatic scaling and load balancing, secrets management, and built-in metrics and log forwarding. Deployments are driven by a single LiveKit CLI command and use your existing Dockerfile.
 
 See the [agent deployment quickstart](https://docs.livekit.io/deploy/agents/quickstart/) to get started.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ For more information about deployment, see the [documentation](https://docs.live
 
 ## Agents on LiveKit Cloud
 
-The easiest way to ship an agent is [agent deployment on LiveKit Cloud](https://docs.livekit.io/deploy/agents/). Your agent runs on LiveKit's global network and infrastructure, with automatic scaling and load balancing, secrets management, and built-in metrics and log forwarding. Deployments are driven by a single LiveKit CLI command and use your existing Dockerfile.
-
-See the [agent deployment quickstart](https://docs.livekit.io/deploy/agents/quickstart/) to get started.
+The easiest way to deploy your agent is [on LiveKit Cloud](https://docs.livekit.io/deploy/agents/). Your agent runs on LiveKit's global network and infrastructure, with automatic scaling and load balancing, secrets management, and built-in metrics and log forwarding. Deployments are driven by a single LiveKit CLI command and use your existing Dockerfile.
 
 ## Dockerfile examples
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository contains a collection of examples to deploy [LiveKit Agents](https://github.com/livekit/agents) into a production environment for a variety of cloud providers.
 
-For more information about deployment, see the [documentation](https://docs.livekit.io/agents/deployment)
+For more information about deployment, see the [documentation](https://docs.livekit.io/deploy/agents/).
 
 ## LiveKit Cloud
 
-The easiest way to deploy an agent is with [LiveKit Cloud Agents](https://docs.livekit.io/agents/ops/deployment/cloud/), a fully-managed hosting service built specifically for LiveKit Agents. It handles scaling, observability, and rollouts for you, so you can ship an agent without managing your own infrastructure.
+The easiest way to deploy an agent is to [deploy it to LiveKit Cloud](https://docs.livekit.io/deploy/agents/). LiveKit Cloud runs your agent on LiveKit's global network and infrastructure, with automatic scaling and load balancing, secrets management, and built-in metrics and log forwarding. Deployments are driven by a single LiveKit CLI command and use your existing Dockerfile.
 
-See the [LiveKit Cloud Agents documentation](https://docs.livekit.io/agents/ops/deployment/cloud/) to get started.
+See the [agent deployment quickstart](https://docs.livekit.io/deploy/agents/quickstart/) to get started.
 
 ## Dockerfile examples
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This repository contains a collection of examples to deploy [LiveKit Agents](htt
 
 For more information about deployment, see the [documentation](https://docs.livekit.io/agents/deployment)
 
+## LiveKit Cloud
+
+The easiest way to deploy an agent is with [LiveKit Cloud Agents](https://docs.livekit.io/agents/ops/deployment/cloud/), a fully-managed hosting service built specifically for LiveKit Agents. It handles scaling, observability, and rollouts for you, so you can ship an agent without managing your own infrastructure.
+
+See the [LiveKit Cloud Agents documentation](https://docs.livekit.io/agents/ops/deployment/cloud/) to get started.
+
 ## Dockerfile examples
 
 The following examples include a bare-bones agent and Dockerfile which is suitable for running in any containerized environment.


### PR DESCRIPTION
## Summary
Updated the README to improve deployment documentation and highlight LiveKit Cloud as the recommended deployment option.

## Changes
- Fixed documentation link URL from `https://docs.livekit.io/agents/deployment` to `https://docs.livekit.io/deploy/agents/` to use the correct documentation path
- Added new "Agents on LiveKit Cloud" section that introduces LiveKit Cloud as the easiest deployment option
- Included details about LiveKit Cloud benefits: global network infrastructure, automatic scaling and load balancing, secrets management, metrics and log forwarding, and CLI-driven deployments using existing Dockerfiles

## Details
The changes improve discoverability of LiveKit Cloud as a deployment solution while maintaining the existing Dockerfile examples section for users who prefer alternative deployment methods.

https://claude.ai/code/session_01WG2pfsyg1MGbTA7odzqr3e