### PR TITLE
Mark repository as deprecated and unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # LiveKit Agents deployment examples
 
 > [!WARNING]
-> **This repository is deprecated and unmaintained as of 2026.**
+> **These examples are deprecated and unmaintained as of 2026. They may be out of date.**
 >
-> It will be archived to read-only shortly after this notice is posted. The examples here are no longer being updated and may be out of date.
->
-> For current deployment guidance, please refer to the official documentation:
-> - **General deployment advice (including LiveKit Cloud):** https://docs.livekit.io/deploy/agents/
-> - **Self-hosted deployment:** https://docs.livekit.io/deploy/custom/deployments/
+> For current LiveKit Agents deployment guidance, refer to the [official documentation](https://docs.livekit.io/deploy/agents/).
 
 This repository contains a collection of examples to deploy [LiveKit Agents](https://github.com/livekit/agents) into a production environment for a variety of cloud providers.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # LiveKit Agents deployment examples
 
+> [!WARNING]
+> **This repository is deprecated and unmaintained as of 2026.**
+>
+> It will be archived to read-only shortly after this notice is posted. The examples here are no longer being updated and may be out of date.
+>
+> For current deployment guidance, please refer to the official documentation:
+> - **General deployment advice (including LiveKit Cloud):** https://docs.livekit.io/deploy/agents/
+> - **Self-hosted deployment:** https://docs.livekit.io/deploy/custom/deployments/
+
 This repository contains a collection of examples to deploy [LiveKit Agents](https://github.com/livekit/agents) into a production environment for a variety of cloud providers.
 
 For more information about deployment, see the [documentation](https://docs.livekit.io/deploy/agents/).


### PR DESCRIPTION
## Summary
Added a deprecation notice to the README to inform users that this repository is no longer maintained as of 2026 and will be archived to read-only status.

## Changes
- Added a prominent warning box at the top of the README indicating the repository is deprecated and unmaintained
- Directed users to official LiveKit documentation for current deployment guidance:
  - General deployment advice and LiveKit Cloud deployment
  - Self-hosted deployment instructions
- Clarified that examples in this repository are no longer being updated and may be out of date

## Details
The deprecation notice uses GitHub's warning syntax (`> [!WARNING]`) to ensure high visibility for anyone visiting the repository. Users are provided with direct links to the official documentation to help them find current, maintained resources.

https://claude.ai/code/session_01LdCmaS3SFb8h5xhPDtzfMx